### PR TITLE
Fix deploy script on main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,7 +124,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Copy to latest directory
-        run: cp -r target/site/apidocs/ docs/api/latest/
+        run: cp -r target/site/apidocs/ docs/api/latest
 
       - name: Copy to versioned directory
         run: cp -r target/site/apidocs "docs/api/$curr_version/"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout last commit
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.push.before }}
+          ref: ${{ github.event.before }}
 
       - name: Get last POM version
         run: |


### PR DESCRIPTION
The latest release (v1.1/#1) did not go as smoothly as one would hope.

For starters, the `mvn deploy` did not even run, as the `check_version_bump` did not detect a changed POM version. This was due to a syntactical error in the workflow.

Also, the Javadoc deploy did not copy the updated site into the `latest/` directory properly. This, again, was due to a slight syntactical error in the `cp` command.

Both of these issues are resolved in this pull.