### PR TITLE
Fix copy command for Javadoc deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,10 +124,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Copy to latest directory
-        run: cp -r target/site/apidocs/ docs/api/latest
+        run: cp -r target/site/apidocs/* docs/api/latest/
 
       - name: Copy to versioned directory
-        run: cp -r target/site/apidocs "docs/api/$curr_version/"
+        run: |
+          mkdir -p "docs/api/$curr_version"
+          cp -r target/site/apidocs/* "docs/api/$curr_version/"
 
       - name: Deploy changes
         run: |


### PR DESCRIPTION
Amendment from #2.

The copy command, despite working on macOS, did not produce proper results on the Ubuntu runner used on Github Actions. Rather than spend hours investigating this, I'm using globbing to fix this.