### PR TITLE
Add Vocareum support (v1.2)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Purdue University Department of Computer Science
+Copyright (c) 2020-2021 Purdue University Department of Computer Science
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build](https://img.shields.io/github/workflow/status/purduecsbridge/percolator/Deploy/main)](https://github.com/purduecsbridge/percolator/actions?query=workflow%3A%22Deploy%22+branch%3Amain)
 [![javadoc](https://img.shields.io/badge/docs-javadoc-blue)](https://purduecsbridge.github.io/percolator/api/latest)
 
-Percolator is a grading package for Java Gradescope assignments. It is meant to make the development and maintenance of programming assignments easier for courses using Java. How easy is it?
+Percolator is a grading framework for Java programming assignments on Gradescope and Vocareum. It is meant to make the development and maintenance of programming assignments easier for courses using Java. How easy is it?
 
 ```java
 import edu.purdue.cs.percolator.TestCase;
@@ -66,6 +66,23 @@ public class TestRunner {
 ```
 
 The [StyleChecker](https://purduecsbridge.github.io/percolator/api/latest/edu/purdue/cs/percolator/StyleChecker.html) audits the Java source files in a given directory and enforces the rules defined in a [Checkstyle configuration](https://checkstyle.org/config.html).
+
+By default, the [AutoGrader](https://purduecsbridge.github.com/percolator/api/latest/edu/purdue/cs/percolator/AutoGrader.html) will assume you are using Gradescope. If you are using Vocareum instead, just use the `onVocareum()` method when constructing your AutoGrader.
+
+```java
+import edu.purdue.cs.percolator.AutoGrader;
+
+public class TestRunner {
+
+    public static void main(String[] args) {
+        String[] testSuites = {TestSuiteOne.class, TestSuiteTwo.class};
+        AutoGrader.grade(testSuites)
+                .onVocareum()
+                .run();
+    }
+
+}
+```
 
 ## Installation
 Instructions on how to add Percolator to your Maven project can be found [here](https://github.com/purduecsbridge/percolator/packages/).

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
 
   <groupId>edu.purdue.cs</groupId>
   <artifactId>percolator</artifactId>
-  <version>1.1</version>
+  <version>1.2</version>
 
   <name>Percolator</name>
-  <description>Grading framework for Java assignments.</description>
+  <description>Grading framework for Java programming assignments.</description>
   <url>https://github.com/purduecsbridge/percolator</url>
   <inceptionYear>2020</inceptionYear>
   <organization>

--- a/src/main/java/edu/purdue/cs/percolator/GradescopeFormatter.java
+++ b/src/main/java/edu/purdue/cs/percolator/GradescopeFormatter.java
@@ -1,0 +1,40 @@
+package edu.purdue.cs.percolator;
+
+import com.github.tkutcher.jgrade.Grader;
+import com.github.tkutcher.jgrade.gradescope.GradescopeJsonFormatter;
+
+/**
+ * The {@link GradescopeFormatter} class formats grading results
+ * and prints them out so Gradescope can assign grades and display
+ * the results.
+ *
+ * @author Andrew Davis, asd@alumni.purdue.edu
+ * @version 1.2
+ * @since 1.2
+ */
+class GradescopeFormatter implements OutputFormatter {
+
+    /**
+     * Inner {@link GradescopeJsonFormatter} object to handle JSON formatting.
+     */
+    private final GradescopeJsonFormatter formatter;
+
+    /**
+     * Creates a new {@link GradescopeFormatter}.
+     */
+    GradescopeFormatter() {
+        this.formatter = new GradescopeJsonFormatter();
+        this.formatter.setPrettyPrint(2);
+    }
+
+    /**
+     * Prints the contents of the {@link Grader} object
+     * to standard out.
+     *
+     * @param grader the test case grader
+     */
+    public void printGradingResults(Grader grader) {
+        System.out.println(this.formatter.format(grader));
+    }
+
+}

--- a/src/main/java/edu/purdue/cs/percolator/OutputFormatter.java
+++ b/src/main/java/edu/purdue/cs/percolator/OutputFormatter.java
@@ -1,0 +1,22 @@
+package edu.purdue.cs.percolator;
+
+import com.github.tkutcher.jgrade.Grader;
+
+/**
+ * The {@link OutputFormatter} interface standardizes formatting output for all
+ * grading platforms.
+ *
+ * @author Andrew Davis, asd@alumni.purdue.edu
+ * @version 1.2
+ * @since 1.2
+ */
+interface OutputFormatter {
+
+    /**
+     * Prints out the contents of the {@link Grader} object.
+     *
+     * @param grader the test case grader
+     */
+    void printGradingResults(Grader grader);
+
+}

--- a/src/main/java/edu/purdue/cs/percolator/TestCaseListener.java
+++ b/src/main/java/edu/purdue/cs/percolator/TestCaseListener.java
@@ -131,7 +131,6 @@ class TestCaseListener extends RunListener {
             if (this.testResults.containsKey(testKey)) {
                 GradedTestResult result = this.testResults.get(testKey);
                 result.setScore(0);
-                result.addOutput("TEST FAILED:\n");
 
                 if (failure.getMessage() != null) {
                     result.addOutput(failure.getMessage());

--- a/src/main/java/edu/purdue/cs/percolator/VocareumFormatter.java
+++ b/src/main/java/edu/purdue/cs/percolator/VocareumFormatter.java
@@ -1,0 +1,120 @@
+package edu.purdue.cs.percolator;
+
+import com.github.tkutcher.jgrade.Grader;
+import com.github.tkutcher.jgrade.gradedtest.GradedTestResult;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The {@link VocareumFormatter} class formats grading results
+ * and prints them out so Vocareum can assign grades and display
+ * the results.
+ *
+ * @author Kedar Abhyankar
+ * @author Andrew Davis, asd@alumni.purdue.edu
+ * @version 1.2
+ * @since 1.2
+ */
+class VocareumFormatter implements OutputFormatter {
+
+    /**
+     * The header displayed before test output.
+     */
+    private final static String TEST_OUTPUT_HEADER = "TEST CASES\n" +
+        "==========";
+
+    /**
+     * The header displayed before code style output.
+     */
+    private final static String CODE_STYLE_HEADER = "CODE STYLE\n" +
+        "==========";
+
+    /**
+     * Prints the contents of the {@link Grader} object
+     * to standard out/error.
+     *
+     * @param grader the test case grader
+     */
+    public void printGradingResults(Grader grader) {
+        List<GradedTestResult> testCases = grader.getGradedTestResults();
+
+        // Extract Code Style result, if applicable
+        GradedTestResult codeStyle = null;
+        if (testCases.get(testCases.size() - 1).getName().equals(StyleChecker.TEST_RESULT_NAME)) {
+            codeStyle = testCases.get(testCases.size() - 1);
+            testCases.remove(codeStyle);
+        }
+
+        printGradingReport(testCases, codeStyle);
+        printGradingResults(testCases, codeStyle);
+    }
+
+    /**
+     * Prints the grading report to {@link System#err}.
+     *
+     * @param testCases the test case results
+     * @param codeStyle the code style result
+     */
+    private static void printGradingReport(List<GradedTestResult> testCases, GradedTestResult codeStyle) {
+        System.err.println(TEST_OUTPUT_HEADER);
+
+        // TEST CASES (passed)
+        AtomicInteger numTestCasesPassed = new AtomicInteger();
+        testCases.stream().filter(GradedTestResult::passed).forEach(r -> {
+            if (!r.getNumber().isBlank()) {
+                System.err.printf("%s) ", r.getNumber());
+            }
+            System.err.printf("PASSED: %s\n", r.getName());
+            numTestCasesPassed.incrementAndGet();
+        });
+
+        if (numTestCasesPassed.get() != 0) {
+            System.err.print("\n");
+        }
+
+        // TEST CASES (failed)
+        AtomicInteger numTestCasesFailed = new AtomicInteger();
+        testCases.stream().filter(r -> !r.passed()).forEach(r -> {
+            if (!r.getNumber().isBlank()) {
+                System.err.printf("%s) ", r.getNumber());
+            }
+            System.err.printf("FAILED: %s\n", r.getName());
+            System.err.println(r.getOutput());
+            numTestCasesFailed.incrementAndGet();
+        });
+
+        if (numTestCasesFailed.get() == 0) {
+            System.err.println("ALL TESTS PASS!");
+        } else {
+            System.err.printf("%d TEST%s FAILED.\n",
+                numTestCasesFailed.get(),
+                numTestCasesFailed.get() == 1 ? "" : "S"
+            );
+        }
+
+        // CODE STYLE
+        if (codeStyle != null) {
+            System.err.println("\n\n" + CODE_STYLE_HEADER);
+            System.err.println(codeStyle.getOutput());
+        }
+    }
+
+    /**
+     * Prints the grading results to {@link System#out}.
+     *
+     * @param testCases the test case results
+     * @param codeStyle the code style result
+     */
+    private static void printGradingResults(List<GradedTestResult> testCases, GradedTestResult codeStyle) {
+        double testCasesScore = testCases.stream()
+            .mapToDouble(GradedTestResult::getScore)
+            .sum();
+        System.out.println("Test Cases," + testCasesScore);
+
+        if (codeStyle != null) {
+            System.out.println(StyleChecker.TEST_RESULT_NAME + "," + codeStyle.getScore());
+        }
+    }
+
+}

--- a/src/main/java/edu/purdue/cs/percolator/util/DebugUtilities.java
+++ b/src/main/java/edu/purdue/cs/percolator/util/DebugUtilities.java
@@ -44,7 +44,8 @@ public final class DebugUtilities {
     public static void failWithStackTrace(Throwable e) {
         ByteArrayOutputStream error = new ByteArrayOutputStream();
         e.printStackTrace(new PrintStream(error));
-        Assert.fail(error.toString());
+        String failureMessage = String.format("Unexpected Exception during execution: %n%s", error.toString());
+        Assert.fail(failureMessage);
     }
 
 }

--- a/src/main/java/edu/purdue/cs/percolator/util/StringUtilities.java
+++ b/src/main/java/edu/purdue/cs/percolator/util/StringUtilities.java
@@ -39,27 +39,29 @@ public final class StringUtilities {
      * Asserts that two {@link String}s are "fuzzy-equal"
      * (i.e., ignoring all whitespace and capitalization).
      *
-     * @param message the assertion message to display
-     * @param s1      the first {@link String}
-     * @param s2      the second {@link String}
+     * @param message  the assertion message to display
+     * @param expected the expected {@link String}
+     * @param actual   the actual {@link String}
      * @throws AssertionError if the {@link String}s are not "fuzzy-equal"
      */
-    public static void assertFuzzyEquals(String message, String s1, String s2) throws AssertionError {
-        s1 = removeAllWhitespace(s1).toLowerCase();
-        s2 = removeAllWhitespace(s2).toLowerCase();
-        Assert.assertEquals(message, s1, s2);
+    public static void assertFuzzyEquals(String message, String expected, String actual) throws AssertionError {
+        String s1 = removeAllWhitespace(expected).toLowerCase();
+        String s2 = removeAllWhitespace(actual).toLowerCase();
+        if (!s1.equals(s2)) {
+            Assert.assertEquals(message, expected, actual);
+        }
     }
 
     /**
      * Asserts that two {@link String}s are "fuzzy-equal"
      * (i.e., ignoring all whitespace and capitalization).
      *
-     * @param s1 the first {@link String}
-     * @param s2 the second {@link String}
+     * @param expected the expected {@link String}
+     * @param actual   the actual {@link String}
      * @throws AssertionError if the {@link String}s are not "fuzzy-equal"
      */
-    public static void assertFuzzyEquals(String s1, String s2) throws AssertionError {
-        assertFuzzyEquals(null, s1, s2);
+    public static void assertFuzzyEquals(String expected, String actual) throws AssertionError {
+        assertFuzzyEquals(null, expected, actual);
     }
 
     /**


### PR DESCRIPTION
# Percolator
See [project page](https://github.com/purduecsbridge/percolator) for more details.

## Release Notes (1.2)
- Added support for [Vocareum](https://www.vocareum.com)
  - `AutoGrader.onVocareum()` can be used to print grading results to a format that Vocareum can use.
  - Rubric items inside of Vocareum should be "Test Cases" and "Code Style". Omit "Code Style" if you do not use a `StyleChecker` in your `AutoGrader` construction.
  - Users should be aware that the grading report will be printed to `stderr`, while the rubric items are printed to `stdout`. One way of redirecting the outputs correctly is provided in the Javadoc.
- Updated output of `StringUtilities.assertFuzzyEquals()`
  - This method will now display the original strings, rather than the strings in lowercase with all whitespace removed.
  - The parameters `(s1, s2)` have been renamed to `(expected, actual)` to match JUnit.
- Added better failure message to`DebugUtilities.failWithStackTrace()`
  -  This method will now prepend the stack trace with "Unexpected Exception during execution."
- Updated license date