### PR TITLE
Use my website for URL instead of GitHub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <developer>
       <name>Andrew Davis</name>
       <email>asd@alumni.purdue.edu</email>
-      <url>https://github.com/drewdavis418</url>
+      <url>https://www.drewdavis.me</url>
     </developer>
   </developers>
 


### PR DESCRIPTION
Updating my URL in the POM to use my website instead of my GitHub profile.